### PR TITLE
refactor: move createConfig out of component, remove turnkey iframe

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,6 @@
 import { LogInCard } from "@/components/LogInCard";
 import { ProfileCard } from "@/components/ProfileCard";
 import { useAccount, useUser } from "@alchemy/aa-alchemy/react";
-import { TurnkeyIframe } from "../components/TurnkeyIframe";
 
 export default function Home() {
   const { account, isLoadingAccount } = useAccount({
@@ -26,7 +25,6 @@ export default function Home() {
       ) : (
         <LogInCard />
       )}
-      <TurnkeyIframe />
     </main>
   );
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,13 +6,13 @@ import { arbitrumSepolia } from "@alchemy/aa-core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PropsWithChildren, Suspense } from "react";
 
-export const Providers = (props: PropsWithChildren) => {
-  const queryClient = new QueryClient();
-  const config = createConfig({
-    rpcUrl: "/api/rpc",
-    chain: arbitrumSepolia,
-  });
+const queryClient = new QueryClient();
+const config = createConfig({
+  rpcUrl: "/api/rpc",
+  chain: arbitrumSepolia,
+});
 
+export const Providers = (props: PropsWithChildren) => {
   return (
     <Suspense>
       <QueryClientProvider client={queryClient}>

--- a/src/components/TurnkeyIframe.tsx
+++ b/src/components/TurnkeyIframe.tsx
@@ -1,9 +1,0 @@
-export const TurnkeyIframe = () => {
-  return (
-    <div
-      className="w-full"
-      style={{ display: "none" }}
-      id="turnkey-iframe-container-id"
-    ></div>
-  );
-};


### PR DESCRIPTION
Learned from @moldy530 that we should move the createConfig out of components so it doesnt re-create on render, and then this will create the turnkey iframe - reflected in the docs change here: https://github.com/alchemyplatform/aa-sdk/pull/621